### PR TITLE
Use ocaml-xen-lowlevel-libs-devel instead of xen-ocaml-devel

### DIFF
--- a/rrdd-plugins.spec.in
+++ b/rrdd-plugins.spec.in
@@ -14,9 +14,9 @@ BuildRequires:  ocaml
 BuildRequires:  forkexecd-devel
 BuildRequires:  ocaml-xcp-idl-devel
 BuildRequires:  ocaml-xen-api-libs-transitional-devel
+BuildRequires:  ocaml-xen-lowlevel-libs-devel
 BuildRequires:  ocaml-xenops-devel
 BuildRequires:  ocaml-xenstore-devel
-BuildRequires:  xen-ocaml-devel
 Requires:       xsifstat
 Requires:       xsiostat
 


### PR DESCRIPTION
Other packages are already using ocaml-xen-lowlevel-libs-devel, and xen-ocaml-devel conflicts with this.
