### PR TITLE
CP-9977 - Switch to Xen's ocaml libraries for xenctrl and xenlight

### DIFF
--- a/rrdd-plugins.spec.in
+++ b/rrdd-plugins.spec.in
@@ -16,7 +16,7 @@ BuildRequires:  forkexecd-devel
 BuildRequires:  ocaml-rrdd-plugin-devel
 BuildRequires:  ocaml-xcp-idl-devel
 BuildRequires:  ocaml-xen-api-libs-transitional-devel
-BuildRequires:  ocaml-xen-lowlevel-libs-devel
+BuildRequires:  xen-ocaml-devel
 BuildRequires:  ocaml-xenops-devel
 BuildRequires:  ocaml-xenstore-devel
 BuildRequires:  ocaml-xcp-rrd-devel


### PR DESCRIPTION
This pull request needs to be done in combination with a similar one in xen-api-libs-specs, and an internal alighment with a change in the Xen repository

https://github.com/xenserver/xen-api-libs-specs/pull/94
