### PR TITLE
Speed up builds

### DIFF
--- a/mock/default.cfg
+++ b/mock/default.cfg
@@ -3,9 +3,14 @@ config_opts['target_arch'] = 'x86_64'
 config_opts['root'] = 'dom0'
 config_opts['legal_host_arches'] = ('x86_64',)
 config_opts['chroot_setup_cmd'] = 'install bash bzip2 coreutils cpio diffutils findutils gawk gcc gcc-c++ grep gzip info make patch redhat-rpm-config rpm-build sed shadow-utils tar unzip util-linux-ng which xz'
+config_opts['chroot_setup_cmd'] += ' ocaml omake blktap-devel xen-dom0-libs-devel xen-libs-devel'
 config_opts['dist'] = 'el6'  # only useful for --resultdir variable subst
 config_opts['plugin_conf']['bind_mount_opts']['dirs'].append(('/output', '/output' ))
 config_opts['plugin_conf']['bind_mount_opts']['dirs'].append(('/var/xen-mock', '/var/xen-mock'))
+config_opts['plugin_conf']['root_cache_opts']['exclude_dirs'] = ["./proc", "./sys", "./dev",
+                                                                 "./tmp/ccache", "./var/cache/yum",
+                                                                 "./output", "./var/xen-mock",
+                                                                 "./obj" ]
 
 config_opts['yum.conf'] = """
 [epel]


### PR DESCRIPTION
Improve build speed by:
1) Excluding various bind mounted directories that balloon up the size
of root_cache.tar.gz to a few gigabytes which then means all the build
time is spent on disk IO.

2) Include a bunch of commonly required dependencies in the root cache
to reduce the time spent running yum-builddep for each mock call.

Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>