### PR TITLE
Speed up builds

### DIFF
--- a/mock/default.cfg
+++ b/mock/default.cfg
@@ -6,6 +6,10 @@ config_opts['chroot_setup_cmd'] = 'install bash bzip2 coreutils cpio diffutils f
 config_opts['dist'] = 'el6'  # only useful for --resultdir variable subst
 config_opts['plugin_conf']['bind_mount_opts']['dirs'].append(('/output', '/output' ))
 config_opts['plugin_conf']['bind_mount_opts']['dirs'].append(('/var/xen-mock', '/var/xen-mock'))
+config_opts['plugin_conf']['root_cache_opts']['exclude_dirs'] = ["./proc", "./sys", "./dev",
+                                                                 "./tmp/ccache", "./var/cache/yum",
+                                                                 "./output", "./var/xen-mock",
+                                                                 "./obj" ]
 
 config_opts['yum.conf'] = """
 [epel]


### PR DESCRIPTION
Improve build speed by excluding various bind mounted directories that balloon
up the size of root_cache.tar.gz to a few gigabytes which then means all the
build time is spent on disk IO. (the root cache went from 2.4GB to 155MB)