### PR TITLE
CA-186157: xsiostat: Add xen-libs-devel build dependency

### DIFF
--- a/SPECS/xsiostat.spec
+++ b/SPECS/xsiostat.spec
@@ -10,6 +10,7 @@ Group:          Development/Other
 URL:            https://github.com/xenserver/xsiostat/
 Source0:        git://github.com/xenserver/xsiostat
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}
+BuildRequires:  xen-libs-devel
 
 %description
 The xsiostat is a tool similar to iostat but that consider XenServer components


### PR DESCRIPTION
It is required to access xenstore by xsiostat