### PR TITLE
CA-186157: xsiostat: Add blktap-devel dependency

### DIFF
--- a/SPECS/xsiostat.spec
+++ b/SPECS/xsiostat.spec
@@ -10,6 +10,7 @@ Group:          Development/Other
 URL:            https://github.com/xenserver/xsiostat/
 Source0:        git://github.com/xenserver/xsiostat
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}
+BuildRequires:  blktap-devel
 BuildRequires:  xen-libs-devel
 
 %description


### PR DESCRIPTION
It is required to access tapdisk stats structure