### PR TITLE
CP-18110 Update perf-tools spec files for the Transformer build system

### DIFF
--- a/SPECS/gpumon.spec
+++ b/SPECS/gpumon.spec
@@ -1,6 +1,6 @@
 Name:           gpumon
-Version:        0.2.0
-Release:        2%{?dist}
+Version:        0.3.0
+Release:        1%{?dist}
 Summary:        RRDD GPU metrics plugin
 Group:          System/Hypervisor
 License:        LGPL+linking exception
@@ -67,6 +67,9 @@ esac
 /opt/xensource/libexec/xcp-rrdd-plugins/xcp-rrdd-gpumon
 
 %changelog
+* Tue Aug 16 2016 Christian Lindig <christian.lindig@citrix.com> - 0.3.0-1
+- Update to 0.3.0 for new upstream release
+
 * Mon May 16 2016 Si Beaumont <simon.beaumont@citrix.com> - 0.2.0-1
 - Re-run chkconfig on upgrade
 - Stop service on uninstall

--- a/SPECS/rrd2csv.spec
+++ b/SPECS/rrd2csv.spec
@@ -1,5 +1,5 @@
 Name:           rrd2csv
-Version:        1.0.0
+Version:        1.0.1
 Release:        1%{?dist}
 Summary:        Tool for converting Xen API RRDs to CSV
 License:        LGPL+linking exception
@@ -38,6 +38,9 @@ rm -rf %{buildroot}
 /opt/xensource/man/man1/rrd2csv.1.man
 
 %changelog
+*Tue Aug 16 2016 Christian Lindig <christian.lindig@citrix.com> - 1.0.1-1
+- Bump version to track new upstream release
+
 * Tue Apr 26 2016 Si Beaumont <simon.beaumont@citrix.com> - 1.0.0-1
 - Update to 1.0.0
 

--- a/SPECS/rrdd-plugins.spec
+++ b/SPECS/rrdd-plugins.spec
@@ -1,6 +1,6 @@
 Name:           rrdd-plugins
-Version:        1.0.1
-Release:        3%{?dist}
+Version:        1.0.2
+Release:        1%{?dist}
 Summary:        RRDD metrics plugins
 License:        LGPL+linking exception
 Group:          System/Hypervisor
@@ -78,6 +78,10 @@ esac
 /etc/xensource/bugtool/xcp-rrdd-plugins/stuff.xml
 
 %changelog
+* Tue Aug 16 2016 Christian Lindig <christian.lindig@citrix.com> - 1.0.2-1
+- Update to 1.0.2
+- Bump version to match new upstream version
+
 * Mon May 16 2016 John Else <john.else@citrix.com> - 1.0.1-3
 - Update to 1.0.1
 - Bump release to 3 for upgrade against old versions


### PR DESCRIPTION
This PR includes updates to spec files to make them work in the Transformer build system. Copies of these spec files are now in the Transformer repository: code.citrite.net/xs/xenserver-specs.git.

All changes are limited to updating version number such that a package correctly tracks the upstream releases.

