### PR TITLE
CA-220044: xcp-rrdd-plugins: don't capture stdout

### DIFF
--- a/SOURCES/xcp-rrdd-gpumon.service
+++ b/SOURCES/xcp-rrdd-gpumon.service
@@ -8,6 +8,7 @@ Wants=syslog.target
 Environment=OCAMLRUNPARAM=b
 ExecStart=/opt/xensource/libexec/xcp-rrdd-plugins/xcp-rrdd-gpumon
 SuccessExitStatus=0 2
+StandardOutput=null
 StandardError=null
 
 [Install]

--- a/SOURCES/xcp-rrdd-iostat.service
+++ b/SOURCES/xcp-rrdd-iostat.service
@@ -5,6 +5,7 @@ Requires=xcp-rrdd.service
 
 [Service]
 ExecStart=/opt/xensource/libexec/xcp-rrdd-plugins/xcp-rrdd-iostat
+StandardOutput=null
 StandardError=null
 
 [Install]

--- a/SOURCES/xcp-rrdd-squeezed.service
+++ b/SOURCES/xcp-rrdd-squeezed.service
@@ -5,6 +5,7 @@ Requires=xcp-rrdd.service
 
 [Service]
 ExecStart=/opt/xensource/libexec/xcp-rrdd-plugins/xcp-rrdd-squeezed
+StandardOutput=null
 StandardError=null
 
 [Install]

--- a/SOURCES/xcp-rrdd-xenpm.service
+++ b/SOURCES/xcp-rrdd-xenpm.service
@@ -5,6 +5,7 @@ Requires=xcp-rrdd.service
 
 [Service]
 ExecStart=/opt/xensource/libexec/xcp-rrdd-plugins/xcp-rrdd-xenpm
+StandardOutput=null
 StandardError=null
 
 [Install]


### PR DESCRIPTION
These plugins produce a lot of logging on stdout when not daemonized.  This is
captured by systemd and results in a lot of spam in daemon.log.

This spam wasn't present when run daemonized, as was the case when run by the
SYSV init script.

Disabling this does not affect the logging done by the plugins via syslog (for
which info-level and above logging normally ends up in
/var/log/xcp-rrdd-plugins.log).

Signed-off-by: Jonathan Davies <jonathan.davies@citrix.com>