### PR TITLE
HFX-1986: New release for rrd2csv and rrdd-plugins

### DIFF
--- a/SPECS/rrd2csv.spec
+++ b/SPECS/rrd2csv.spec
@@ -1,6 +1,6 @@
 Name:           rrd2csv
 Version:        1.0.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Tool for converting Xen API RRDs to CSV
 License:        LGPL+linking exception
 Group:          System/Hypervisor
@@ -38,6 +38,10 @@ rm -rf %{buildroot}
 /opt/xensource/man/man1/rrd2csv.1.man
 
 %changelog
+* Mon Sep 18 2017 Frederico Mazzone <frederico.mazzone@citrix.com> - 1.0.0-2
+- HFX-1986: Compile against new xen-api-libs-transitional which
+  contains the fix for CA-245559
+
 * Tue Apr 26 2016 Si Beaumont <simon.beaumont@citrix.com> - 1.0.0-1
 - Update to 1.0.0
 

--- a/SPECS/rrdd-plugins.spec
+++ b/SPECS/rrdd-plugins.spec
@@ -1,6 +1,6 @@
 Name:           rrdd-plugins
 Version:        1.0.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        RRDD metrics plugins
 License:        LGPL+linking exception
 Group:          System/Hypervisor
@@ -78,6 +78,10 @@ esac
 /etc/xensource/bugtool/xcp-rrdd-plugins/stuff.xml
 
 %changelog
+* Mon Sep 18 2017 Frederico Mazzone <frederico.mazzone@citrix.com> - 1.0.1-3
+- HFX-1986: Compile against new xen-api-libs-transitional which
+  contains the fix for CA-245559
+
 * Mon May 16 2016 Si Beaumont <simon.beaumont@citrix.com> - 1.0.1-2
 - Re-run chkconfig on upgrade
 - Stop service on uninstall


### PR DESCRIPTION
Backporting CA-245559 has changed ocaml-xen-api-libs-transitional
and so rrd2csv and rrdd-plugins must be re-compiled and re-released
to include this change.

Signed-off-by: Frederico Mazzone <frederico.mazzone@citrix.com>