### PR TITLE
HFX-1989: Backport CA-248332: Fix-race condition in iostat

### DIFF
--- a/SOURCES/HFX-1989-CA-248332-Fix-race-condition-in-iostat.patch
+++ b/SOURCES/HFX-1989-CA-248332-Fix-race-condition-in-iostat.patch
@@ -1,0 +1,46 @@
+From e6294862b2624309dd4ba321a1d053673ea860ee Mon Sep 17 00:00:00 2001
+From: Sharad Yadav <sharad.yadav@citrix.com>
+Date: Thu, 20 Apr 2017 15:09:31 +0100
+Subject: [PATCH] CA-248332: Fix race condition in iostat while updating
+ VDI-to-VM map.
+
+There is a window when the tapdisk is created but the VBDs are not,
+and if VDI-to-VM map is updated during this window then the daemon will not
+try to update the map again until the next tapdisk is created.
+
+This fix will call `update_vdi_to_vm_map` if any of the tapdisk
+known doesn't have corresponding entries in the VDI-to-VM map.
+
+Signed-off-by: Sharad Yadav <sharad.yadav@citrix.com>
+---
+ src/rrdp_iostat.ml | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/rrdp_iostat.ml b/src/rrdp_iostat.ml
+index 76f83f7..77fe7dc 100644
+--- a/src/rrdp_iostat.ml
++++ b/src/rrdp_iostat.ml
+@@ -258,7 +258,7 @@ let exec_tap_ctl () =
+ 			update_vdi_to_vm_map ()
+ 		end else
+ 			let disappeared_pids = List.set_difference !previous_map pid_and_minor_to_sr_and_vdi in
+-			let appeared_pids    = List.set_difference pid_and_minor_to_sr_and_vdi !previous_map in
++			let unmapped_vdi_pids = List.filter (fun (_, (_, (_, vdi))) -> not (List.mem_assoc vdi !vdi_to_vm_map)) pid_and_minor_to_sr_and_vdi in
+ 
+ 			List.iter (fun (pid, (_, (_, vdi))) ->
+ 				try
+@@ -268,9 +268,9 @@ let exec_tap_ctl () =
+ 					D.debug "no knowledge about pid %d; ignoring" pid
+ 			) disappeared_pids;
+ 
+-			if appeared_pids <> [] then begin
++			if unmapped_vdi_pids <> [] then begin
+ 				let pids_to_string pids = pids |> List.map (fun (pid, (_, (_, vdi))) -> Printf.sprintf "%d (%s)" pid vdi) |> String.concat "; " in
+-				D.info "There are new tapdisk processes: [%s]; updating VDI-to-VM map..." (pids_to_string appeared_pids);
++				D.info "There are new tapdisk processes: [%s]; updating VDI-to-VM map..." (pids_to_string unmapped_vdi_pids);
+ 				(* Unfortunately the only way of identifying which VMs the new tapdisks service is to refresh the entire map *)
+ 				update_vdi_to_vm_map ()
+ 			end
+-- 
+2.7.4
+

--- a/SPECS/rrdd-plugins.spec
+++ b/SPECS/rrdd-plugins.spec
@@ -1,11 +1,12 @@
 Name:           rrdd-plugins
 Version:        1.0.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        RRDD metrics plugins
 License:        LGPL+linking exception
 Group:          System/Hypervisor
 URL:            https://github.com/xenserver/rrdd-plugins/
 Source0:        https://github.com/xenserver/rrdd-plugins/archive/%{version}/rrdd-plugins-%{version}.tar.gz
+Patch0:         HFX-1989-CA-248332-Fix-race-condition-in-iostat.patch
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}
 BuildRequires:  ocaml
 BuildRequires:  oasis
@@ -33,6 +34,7 @@ various metrics.
 
 %prep
 %setup -q
+%patch0 -p1
 
 %build
 mkdir -p %{buildroot}
@@ -78,6 +80,10 @@ esac
 /etc/xensource/bugtool/xcp-rrdd-plugins/stuff.xml
 
 %changelog
+* Tue Sep 19 2017 Frederico Mazzone <frederico.mazzone@citrix.com> - 1.0.1-4
+- HFX-1989: Add patch for backporting fix for CA-248332: Fix race
+  condition in iostat while updating VDI-to-VM map
+
 * Mon Sep 18 2017 Frederico Mazzone <frederico.mazzone@citrix.com> - 1.0.1-3
 - HFX-1986: Compile against new xen-api-libs-transitional which
   contains the fix for CA-245559


### PR DESCRIPTION
The `SOURCES` directory was also added to the repo now to house
the new patch for this backport.

Signed-off-by: Frederico Mazzone <frederico.mazzone@citrix.com>